### PR TITLE
Bump active record dependency to less than 6.3

### DIFF
--- a/otr-activerecord.gemspec
+++ b/otr-activerecord.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1.0'
 
-  gem.add_runtime_dependency 'activerecord', ['>= 4.0', '< 6.1']
+  gem.add_runtime_dependency 'activerecord', ['>= 4.0', '< 6.3']
   gem.add_runtime_dependency 'hashie-forbidden_attributes', '~> 0.1'
 end


### PR DESCRIPTION
Active Record's 6.1 change log isn't very large and doesn't have any overlap with OTR's rake tasks and the middleware sits independently. The largest piece is the legacy connection handling which is controlled outside of any otr interfaces. 

Active Record's 6.2 change log only includes bug fixes. 