### PR TITLE
Stop logging to STDOUT and establishing DB connection on init

### DIFF
--- a/lib/otr-activerecord/activerecord.rb
+++ b/lib/otr-activerecord/activerecord.rb
@@ -26,7 +26,6 @@ module OTR
     def self.configure_from_hash!(spec)
       config = spec.stringify_keys.merge("migrations_paths" => ::OTR::ActiveRecord.migrations_paths)
       ::ActiveRecord::Base.configurations = {rack_env.to_s => config}
-      ::ActiveRecord::Base.establish_connection(rack_env)
     end
 
     # Connect to database with a DB URL. Example: "postgres://user:pass@localhost/db"
@@ -43,7 +42,6 @@ module OTR
           a[env] = {"migrations_paths" => ::OTR::ActiveRecord.migrations_paths}.merge config
           a
         }
-      ::ActiveRecord::Base.establish_connection(rack_env)
     end
 
     # The current Rack environment

--- a/lib/otr-activerecord/compatibility_4.rb
+++ b/lib/otr-activerecord/compatibility_4.rb
@@ -8,7 +8,6 @@ module OTR
       def initialize
         @major_version = 4
         ::ActiveRecord::Base.default_timezone = :utc
-        ::ActiveRecord::Base.logger = Logger.new(STDOUT)
       end
 
       # All db migration dir paths

--- a/lib/otr-activerecord/compatibility_5.rb
+++ b/lib/otr-activerecord/compatibility_5.rb
@@ -8,7 +8,6 @@ module OTR
       def initialize
         @major_version = 5
         ::ActiveRecord::Base.default_timezone = :utc
-        ::ActiveRecord::Base.logger = Logger.new(STDOUT)
       end
 
       # All db migration dir paths

--- a/lib/otr-activerecord/compatibility_6.rb
+++ b/lib/otr-activerecord/compatibility_6.rb
@@ -8,7 +8,6 @@ module OTR
       def initialize
         @major_version = 6
         ::ActiveRecord::Base.default_timezone = :utc
-        ::ActiveRecord::Base.logger = Logger.new(STDOUT)
       end
 
       # All db migration dir paths


### PR DESCRIPTION
Hi,

This PR removes the setting of a default STDOUT logger when requiring the GEM. I think most apps want to control how queries are logged and not log activerecord things into STDOUT

This PR also changes the configure methods not to establish a db connection. For example on an application that has some kind of control process the connection established on initialization cannot be used in the forks anyway.

Think it's also recommended not to connect to the database on boot: 
https://github.com/rails/rails/blob/main/activerecord/lib/active_record/railtie.rb#L254

