### PR TITLE
fix no string conversion to hash for simple db config

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'activerecord', '>6.0'
+gem 'rspec'
+gem 'sqlite3'

--- a/spec/fixtures/multi.yml
+++ b/spec/fixtures/multi.yml
@@ -1,0 +1,24 @@
+.defaults: &defaults
+  adapter: sqlite3
+  database: tmp/multi.sqlite3
+
+development:
+  primary:
+    <<: *defaults
+  reading:
+    <<: *defaults
+    replica: true
+
+production:
+  primary:
+    <<: *defaults
+  reading:
+    <<: *defaults
+    replica: true
+
+test:
+  primary:
+    <<: *defaults
+  reading:
+    <<: *defaults
+    replica: true

--- a/spec/fixtures/simple.yml
+++ b/spec/fixtures/simple.yml
@@ -1,0 +1,12 @@
+.defaults: &defaults
+  adapter: sqlite3
+  database: tmp/simple.sqlite3
+
+development:
+  <<: *defaults
+
+production:
+  <<: *defaults
+
+test:
+  <<: *defaults

--- a/spec/otr-activerecord/activerecord_spec.rb
+++ b/spec/otr-activerecord/activerecord_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe OTR::ActiveRecord do
+  describe '.configure_from_file!' do
+    context 'when simple configuration file is given' do
+      let(:config) { Bundler.root.join('spec/fixtures/simple.yml') }
+
+      it 'configures active record' do
+        described_class.configure_from_file!(config)
+
+        expect(::ActiveRecord::Base.configurations['test']).to eq(
+          adapter: 'sqlite3',
+          database: 'tmp/simple.sqlite3',
+          migrations_paths: ['db/migrate']
+        )
+      end
+    end
+
+    context 'when configuration file with multiple roles given' do
+      let(:config) { Bundler.root.join('spec/fixtures/multi.yml') }
+
+      it 'configures active record' do
+        described_class.configure_from_file!(config)
+
+        expect(::ActiveRecord::Base.configurations['test']).to eq(
+          adapter: 'sqlite3',
+          database: 'tmp/multi.sqlite3',
+          migrations_paths: ['db/migrate']
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'otr-activerecord'
+
+RSpec.configure do |config|
+  config.color = true
+  config.tty = true
+  config.filter_run_when_matching :focus
+end


### PR DESCRIPTION
We've had issues with our single tier db config when trying to upgrade to 2.0.0 from 1.4.2, as we were getting a `No explicit conversion of String to Hash` error where our subconfig (https://github.com/jhollinger/otr-activerecord/blob/6527bda6dd769ba46ee847f1c71c1b4f020a513c/lib/otr-activerecord/activerecord.rb#L66) was a string not a hash due to our database yaml only having single tier roles, after a bit of investigation it seems that this prior PR: https://github.com/jhollinger/otr-activerecord/pull/24 has the changes to support multiple database roles without causing the issues we've had with the current implementation, this is basically that pr without the rubocop and github actions stuff.