### PR TITLE
Fix YAML loading on Ruby 3.1

### DIFF
--- a/lib/otr-activerecord/activerecord.rb
+++ b/lib/otr-activerecord/activerecord.rb
@@ -58,7 +58,7 @@ module OTR
     # Connect to database with a yml file. Example: "config/database.yml"
     def self.configure_from_file!(path)
       raise "#{path} does not exist!" unless File.file? path
-        result =(YAML.safe_load(ERB.new(File.read(path)).result, aliases: true) || {})
+        result = load_yaml(path)
         ::ActiveRecord::Base.configurations = begin
         result.each do |_env, config|
           if config.all? { |_, v| v.is_a?(Hash) }
@@ -84,5 +84,20 @@ module OTR
     def self.rack_env
       (ENV['RACK_ENV'] || ENV['RAILS_ENV'] || ENV['APP_ENV'] || ENV['OTR_ENV'] || 'development').to_sym
     end
+
+    # Support old Psych versions
+    def self.load_yaml(path)
+      erb_result = ERB.new(File.read(path)).result
+
+      result = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
+        YAML.safe_load(erb_result, aliases: true)
+      else
+        YAML.safe_load(erb_result, [], [], true)
+      end
+
+      result || {}
+    end
+
+    private_class_method :load_yaml
   end
 end

--- a/lib/otr-activerecord/activerecord.rb
+++ b/lib/otr-activerecord/activerecord.rb
@@ -58,7 +58,7 @@ module OTR
     # Connect to database with a yml file. Example: "config/database.yml"
     def self.configure_from_file!(path)
       raise "#{path} does not exist!" unless File.file? path
-        result =(YAML.safe_load(ERB.new(File.read(path)).result, [], [], true) || {})
+        result =(YAML.safe_load(ERB.new(File.read(path)).result, aliases: true) || {})
         ::ActiveRecord::Base.configurations = begin
         result.each do |_env, config|
           if config.all? { |_, v| v.is_a?(Hash) }


### PR DESCRIPTION
Hello there! 

I've noticed that this library is not working on ruby 3.1 and doing some debug I've found the following:
Ruby 3.1 uses psych 4.0.3 by default and this version doesn't support the deprecated way we call `YAML.safe_load`.

Before:
```
YAML.safe_load(ERB.new(File.read("config/database.yml")).result, [], [], true)
```

After:
```
YAML.safe_load(ERB.new(File.read("config/database.yml")).result, aliases: true)
```

This new psych version also allows us to use some of the its defaults when calling `safe_load`.

Method definition: https://github.com/ruby/psych/blob/e8d262fa108a1605443d7426c185452b538775be/lib/psych.rb#L323

Ruby 2.6.0 and up uses psych 3.1.0 which introduces this new method signature.

If we want to support old psych versions we will need create a conditional based on the gem version like it's done in this [blog post](https://makandracards.com/makandra/465149-ruby-the-yaml-safe_load-method-hides-some-pitfalls).

Please let me know if changes are needed.

Thank you for your time and effort maintaining this library! 🙇 💐 