### PR TITLE
Ruby 3.2: Use "File.exist?" Instead of "File.exists?"

### DIFF
--- a/lib/tasks/otr-activerecord.rake
+++ b/lib/tasks/otr-activerecord.rake
@@ -60,7 +60,7 @@ namespace :db do
     name, version = args[:name], Time.now.utc.strftime("%Y%m%d%H%M%S")
 
     OTR::ActiveRecord._normalizer.migrations_paths.each do |directory|
-      next unless File.exists?(directory)
+      next unless File.exist?(directory)
       migration_files = Pathname(directory).children
       if duplicate = migration_files.find { |path| path.basename.to_s.include?(name) }
         abort "Another migration is already named \"#{name}\": #{duplicate}."


### PR DESCRIPTION
"File.exists?" is deprecated as of Ruby 3.2

```
NoMethodError: undefined method `exists?' for File:Class
/Users/yosi/.rvm/gems/ruby-3.2.0/gems/otr-activerecord-2.1.1/lib/tasks/otr-activerecord.rake:63:in `block (3 levels) in <top (required)>'
/Users/yosi/.rvm/gems/ruby-3.2.0/gems/otr-activerecord-2.1.1/lib/tasks/otr-activerecord.rake:62:in `each'
```