### PR TITLE
[Deprecation] Use File.exist? instead of File.exists?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+* Use File.exist? instead of File.exists?
+
 ### 2.1.1 (2022-01-30)
 * Fix `OTR::ActiveRecord::QueryCache` for ActiveRecord 7.
 

--- a/lib/tasks/otr-activerecord.rake
+++ b/lib/tasks/otr-activerecord.rake
@@ -60,7 +60,8 @@ namespace :db do
     name, version = args[:name], Time.now.utc.strftime("%Y%m%d%H%M%S")
 
     OTR::ActiveRecord._normalizer.migrations_paths.each do |directory|
-      next unless File.exists?(directory)
+      next unless File.exist?(directory)
+
       migration_files = Pathname(directory).children
       if duplicate = migration_files.find { |path| path.basename.to_s.include?(name) }
         abort "Another migration is already named \"#{name}\": #{duplicate}."


### PR DESCRIPTION
This has been removed on Ruby 3.2.0: https://bugs.ruby-lang.org/issues/17391

So if you're running Ruby 3.2.0, you won't be able to create migrations through the rake task.