### PR TITLE
[Deprecation] use .connection_handler explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+* Use ActiveRecord::Base.connection_handler.clear_active_connections! instead of ActiveRecord::Base.clear_active_connections!
+
 ### 2.2.0 (2023-10-19)
 * Support for ActiveRecord 7.1
 

--- a/lib/otr-activerecord/middleware/connection_management.rb
+++ b/lib/otr-activerecord/middleware/connection_management.rb
@@ -13,12 +13,12 @@ module OTR
 
         resp = @app.call env
         resp[2] = ::Rack::BodyProxy.new resp[2] do
-          ::ActiveRecord::Base.clear_active_connections! unless testing
+          ::ActiveRecord::Base.connection_handler.clear_active_connections! unless testing
         end
         resp
 
       rescue Exception
-        ::ActiveRecord::Base.clear_active_connections! unless testing
+        ::ActiveRecord::Base.connection_handler.clear_active_connections! unless testing
         raise
       end
     end


### PR DESCRIPTION
Using  ```ActiveRecord::Base.clear_active_connections!``` depricated since activerecord 7.1.1  [PR](https://github.com/rails/rails/pull/46274)